### PR TITLE
Add JSON receipt intake and update step flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import logo from "./assets/logos/logo.png";
 import logoBlurple from "./assets/logos/logo-blurple.png";
 import "./App.css";
 
-const tabs = ["Upload Receipt", "People", "Items", "Assign", "Summary"];
+const tabs = ["Upload Receipt", "Items", "People", "Assign", "Summary"];
 
 function App() {
   // Tip input states for Assign/Summary
@@ -58,7 +58,7 @@ function App() {
           if (state.tip !== undefined) setTip(state.tip);
           if (state.tipCalc) setTipCalc(state.tipCalc);
           // Optionally handle taxMode and taxAmount if you store them in state
-          setActiveTab(3); // Go straight to Summary tab
+          setActiveTab(4); // Go straight to Summary tab
         }
       } catch (e) {
         // Optionally show error to user
@@ -67,7 +67,6 @@ function App() {
     }
   }, []);
   const [activeTab, setActiveTab] = useState(0);
-  const [receiptFile, setReceiptFile] = useState(null);
   const [people, setPeople] = useState([]);
   const [emojis, setEmojis] = useState([]);
   const [items, setItems] = useState([]);
@@ -197,24 +196,27 @@ function App() {
         <Card>
           {activeTab === 0 && (
             <UploadReceipt
-              onNext={(file) => {
-                setReceiptFile(file);
+              onNext={({ extractedItems }) => {
+                if (Array.isArray(extractedItems) && extractedItems.length > 0) {
+                  setItems(extractedItems);
+                }
                 setActiveTab(1);
               }}
             />
           )}
           {activeTab === 1 && (
+            <Items
+              items={items}
+              setItems={setItems}
+              setActiveTab={setActiveTab}
+            />
+          )}
+          {activeTab === 2 && (
             <People
               people={people}
               setPeople={setPeople}
               emojis={emojis}
               setEmojis={setEmojis}
-            />
-          )}
-          {activeTab === 2 && (
-            <Items
-              items={items}
-              setItems={setItems}
               setActiveTab={setActiveTab}
             />
           )}

--- a/src/pages/Assign.jsx
+++ b/src/pages/Assign.jsx
@@ -511,7 +511,7 @@ function Assign({
             className="custom-btn tertiary"
             onClick={() => {
               if (typeof setActiveTab === "function") {
-                setActiveTab(3);
+                setActiveTab(4);
               }
               window.scrollTo({ top: 0, behavior: "smooth" });
             }}

--- a/src/pages/Items.jsx
+++ b/src/pages/Items.jsx
@@ -253,7 +253,7 @@ function Items({ items, setItems, setActiveTab }) {
               }}
             >
               <Button
-                label="Next: Assign People to Items"
+                label="Next: Add People"
                 className="custom-btn tertiary"
                 onClick={() => {
                   if (typeof setActiveTab === "function") {

--- a/src/pages/People.jsx
+++ b/src/pages/People.jsx
@@ -24,7 +24,7 @@ const EMOJIS = [
   "🐾",
 ];
 
-function People({ people, setPeople, emojis, setEmojis }) {
+function People({ people, setPeople, emojis, setEmojis, setActiveTab }) {
   const [name, setName] = useState("");
   const [editIdx, setEditIdx] = useState(null);
   const [editName, setEditName] = useState("");
@@ -206,14 +206,14 @@ function People({ people, setPeople, emojis, setEmojis }) {
       </div>
       {people.length > 0 && (
         <Button
-          label="Next: Add Items"
+          label="Next: Assign People to Items"
           className="custom-btn tertiary"
           onClick={() => {
             if (typeof setActiveTab === "function") {
               setActiveTab(3);
             } else {
               window.dispatchEvent(
-                new CustomEvent("changeTab", { detail: { tab: "Items" } })
+                new CustomEvent("changeTab", { detail: { tab: "Assign" } })
               );
             }
             window.scrollTo({ top: 0, behavior: "smooth" });

--- a/src/pages/Summary.jsx
+++ b/src/pages/Summary.jsx
@@ -173,7 +173,7 @@ function Summary({
         <EmptyArea
           text="Assign people to items to calculate total owed for each person."
           buttonLabel="Go to Assign"
-          onButtonClick={() => setActiveTab && setActiveTab(2)}
+          onButtonClick={() => setActiveTab && setActiveTab(3)}
         />
       )}
       {items.length > 0 &&

--- a/src/pages/UploadReceipt.css
+++ b/src/pages/UploadReceipt.css
@@ -42,15 +42,40 @@
   cursor: not-allowed;
 }
 
-.file-preview {
-  margin: 16px 0 8px 0;
+.json-paste-section {
+  width: 100%;
+  margin-top: 12px;
+}
+
+.json-paste-section label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+  text-align: left;
+}
+
+.json-paste-section textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 10px;
+  font-family: monospace;
+  font-size: 0.95rem;
+  resize: vertical;
+}
+
+.json-error,
+.json-success {
+  font-size: 0.95rem;
+  margin: 8px 0 0 0;
   text-align: center;
 }
 
-.receipt-preview-img {
-  max-width: 100%;
-  max-height: 200px;
-  margin-top: 8px;
-  border-radius: 8px;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+.json-error {
+  color: #b91c1c;
+}
+
+.json-success {
+  color: #047857;
 }

--- a/src/pages/UploadReceipt.jsx
+++ b/src/pages/UploadReceipt.jsx
@@ -1,57 +1,147 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import "./UploadReceipt.css";
 
 const UploadReceipt = ({ onNext }) => {
-  const fileInputRef = useRef(null);
-  const [file, setFile] = useState(null);
-  const [previewUrl, setPreviewUrl] = useState(null);
-  const [message, setMessage] = useState("");
+  const [jsonInput, setJsonInput] = useState("");
+  const [jsonError, setJsonError] = useState("");
+  const [extractedItems, setExtractedItems] = useState([]);
 
-  const handleFileChange = (e) => {
-    const selectedFile = e.target.files[0];
-    if (selectedFile) {
-      setFile(selectedFile);
-      setPreviewUrl(URL.createObjectURL(selectedFile));
+  const toNumber = (value) => {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string") {
+      const parsed = parseFloat(value.replace(/[^0-9.-]/g, ""));
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+  };
+
+  const normalizeItem = (item) => {
+    if (!item || typeof item !== "object") return [];
+
+    const quantity = Math.max(
+      1,
+      parseInt(item.quantity ?? item.qty ?? item.count ?? 1, 10) || 1
+    );
+
+    const name =
+      item.name ||
+      item.item ||
+      item.title ||
+      item.description ||
+      item.productName;
+
+    const unitPrice = toNumber(
+      item.unitPrice ??
+        item.unit_price ??
+        item.price ??
+        item.amount ??
+        item.cost
+    );
+    const totalPrice = toNumber(item.totalPrice ?? item.total_price ?? item.total);
+    const resolvedPrice =
+      unitPrice !== null
+        ? unitPrice
+        : totalPrice !== null
+        ? totalPrice / quantity
+        : null;
+
+    if (!name || resolvedPrice === null) return [];
+    return Array.from({ length: quantity }, () => ({
+      name: String(name).trim(),
+      price: resolvedPrice.toFixed(2),
+    }));
+  };
+
+  const getItemsArray = (parsed) => {
+    if (Array.isArray(parsed)) return parsed;
+    if (!parsed || typeof parsed !== "object") return [];
+
+    const candidateKeys = [
+      "items",
+      "orderedItems",
+      "orderItems",
+      "lineItems",
+      "products",
+      "menuItems",
+    ];
+
+    for (const key of candidateKeys) {
+      if (Array.isArray(parsed[key])) return parsed[key];
+    }
+
+    for (const value of Object.values(parsed)) {
+      if (Array.isArray(value)) return value;
+      if (value && typeof value === "object") {
+        const nested = getItemsArray(value);
+        if (nested.length > 0) return nested;
+      }
+    }
+
+    return [];
+  };
+
+  const handleExtractJson = () => {
+    if (!jsonInput.trim()) {
+      setJsonError("Paste JSON first.");
+      setExtractedItems([]);
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(jsonInput);
+      const itemsArray = getItemsArray(parsed);
+      const normalized = itemsArray.flatMap(normalizeItem);
+      if (!normalized.length) {
+        setJsonError(
+          "Could not find ordered items with name and price fields in the JSON."
+        );
+        setExtractedItems([]);
+        return;
+      }
+
+      setExtractedItems(normalized);
+      setJsonError("");
+    } catch {
+      setJsonError("Invalid JSON. Please check the format and try again.");
+      setExtractedItems([]);
     }
   };
 
-  const handleUploadClick = () => {
-    fileInputRef.current.click();
-  };
-
   const handleNext = () => {
-    if (file && onNext) {
-      onNext(file);
+    if (extractedItems.length > 0 && onNext) {
+      onNext({ extractedItems });
     }
   };
 
   return (
     <div className="upload-receipt-container">
       <h2>Upload Receipt</h2>
-      <p>Please upload a photo or PDF of your receipt to get started.</p>
-      <input
-        type="file"
-        accept="image/*,application/pdf"
-        ref={fileInputRef}
-        style={{ display: "none" }}
-        onChange={handleFileChange}
-      />
-      <button className="upload-btn" onClick={handleUploadClick}>
-        Choose File
-      </button>
-      {file && (
-        <div className="file-preview">
-          <p>Selected: {file.name}</p>
-          {previewUrl && file.type.startsWith("image/") && (
-            <img
-              src={previewUrl}
-              alt="Receipt preview"
-              className="receipt-preview-img"
-            />
-          )}
-        </div>
+      <p>Paste your receipt JSON to extract ordered items.</p>
+      <div className="json-paste-section">
+        <label htmlFor="receipt-json-input">Paste receipt JSON</label>
+        <textarea
+          id="receipt-json-input"
+          value={jsonInput}
+          onChange={(e) => setJsonInput(e.target.value)}
+          placeholder='{"items":[{"name":"Pasta","price":14.99}]}'
+          rows={7}
+        />
+        <button className="upload-btn" onClick={handleExtractJson}>
+          Extract Ordered Items
+        </button>
+      </div>
+      {jsonError && <p className="json-error">{jsonError}</p>}
+      {extractedItems.length > 0 && (
+        <p className="json-success">
+          Extracted {extractedItems.length} item
+          {extractedItems.length === 1 ? "" : "s"} from JSON.
+        </p>
       )}
-      <button className="next-btn" onClick={handleNext} disabled={!file}>
+      <button
+        className="next-btn"
+        onClick={handleNext}
+        disabled={extractedItems.length === 0}
+      >
         Next
       </button>
     </div>


### PR DESCRIPTION
## Summary
- add a JSON paste area to Upload Receipt and extract ordered items into the app
- support common receipt item shapes including unit_price/total_price and quantity handling
- remove the Choose File path so JSON paste is the only receipt intake for now
- reorder tabs and navigation to: Upload Receipt -> Items -> People -> Assign -> Summary

## Testing
- npm run build