### PR TITLE
Add receipt photo upload and extraction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ npm run dev
 
 Open http://localhost:5173 in your browser.
 
+### Configure receipt extraction API
+
+Set this environment variable before running serverless APIs locally/deployed:
+
+```sh
+export OPENAI_API_KEY="your_api_key_here"
+```
+
+`POST /api/extract-items` accepts JSON:
+
+```json
+{
+  "imageBase64": "data:image/jpeg;base64,..."
+}
+```
+
+You can also send `"imageUrl"` instead of `"imageBase64"`.  
+Response format:
+
+```json
+{
+  "items": [
+    { "name": "Spicy Tuna Roll", "quantity": 2, "unitPrice": 8.5 }
+  ]
+}
+```
+
 ### Other scripts
 
 | Script | Description |

--- a/api/extract-items.js
+++ b/api/extract-items.js
@@ -1,0 +1,252 @@
+const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+const DEFAULT_MODEL = "gpt-4.1-mini";
+const MAX_IMAGE_BYTES = 7 * 1024 * 1024;
+
+function sendJson(res, status, payload) {
+  return res.status(status).json(payload);
+}
+
+function estimateBase64Bytes(base64Value) {
+  const clean = base64Value.replace(/\s/g, "");
+  const padding = clean.endsWith("==") ? 2 : clean.endsWith("=") ? 1 : 0;
+  return Math.floor((clean.length * 3) / 4) - padding;
+}
+
+function toImageDataUrl(imageBase64) {
+  if (imageBase64.startsWith("data:image/")) return imageBase64;
+  return `data:image/jpeg;base64,${imageBase64}`;
+}
+
+function safePrice(value) {
+  const parsed =
+    typeof value === "number" ? value : Number.parseFloat(String(value));
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Number(parsed.toFixed(2));
+}
+
+function normalizeExtractedItems(payload) {
+  if (!payload || typeof payload !== "object" || !Array.isArray(payload.items)) {
+    return [];
+  }
+
+  return payload.items
+    .map((item) => {
+      if (!item || typeof item !== "object") return null;
+      const name = typeof item.name === "string" ? item.name.trim() : "";
+      const quantity = Math.max(
+        1,
+        Number.parseInt(String(item.quantity ?? 1), 10) || 1
+      );
+      const unitPrice = safePrice(item.unitPrice);
+      if (!name || unitPrice === null) return null;
+      return { name, quantity, unitPrice };
+    })
+    .filter(Boolean);
+}
+
+function parseBody(req) {
+  if (req.body && typeof req.body === "object") {
+    return Promise.resolve(req.body);
+  }
+
+  if (typeof req.body === "string" && req.body.trim()) {
+    try {
+      return Promise.resolve(JSON.parse(req.body));
+    } catch {
+      return Promise.reject(new Error("INVALID_JSON_BODY"));
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8").trim();
+      if (!raw) {
+        reject(new Error("EMPTY_BODY"));
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(new Error("INVALID_JSON_BODY"));
+      }
+    });
+    req.on("error", () => reject(new Error("READ_BODY_FAILED")));
+  });
+}
+
+function extractionSchema() {
+  return {
+    type: "json_schema",
+    json_schema: {
+      name: "receipt_items",
+      strict: true,
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                name: { type: "string" },
+                quantity: { type: "integer", minimum: 1 },
+                unitPrice: { type: "number", minimum: 0 },
+              },
+              required: ["name", "quantity", "unitPrice"],
+            },
+          },
+        },
+        required: ["items"],
+      },
+    },
+  };
+}
+
+async function extractItemsFromImage({ imageReference, model, apiKey }) {
+  const response = await fetch(OPENAI_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      response_format: extractionSchema(),
+      messages: [
+        {
+          role: "system",
+          content:
+            "You extract ordered food/drink items from a restaurant receipt. " +
+            "Return only billable menu items. Exclude tax, tip, fees, discounts, and totals.",
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text:
+                "Extract receipt line items into JSON. " +
+                "If an item appears multiple times, combine with quantity.",
+            },
+            {
+              type: "image_url",
+              image_url: { url: imageReference },
+            },
+          ],
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`OPENAI_ERROR:${response.status}:${errorText}`);
+  }
+
+  const completion = await response.json();
+  const rawContent = completion?.choices?.[0]?.message?.content;
+  if (typeof rawContent !== "string" || !rawContent.trim()) {
+    throw new Error("EMPTY_MODEL_RESPONSE");
+  }
+
+  let parsedContent;
+  try {
+    parsedContent = JSON.parse(rawContent);
+  } catch {
+    throw new Error("INVALID_MODEL_JSON");
+  }
+
+  const normalized = normalizeExtractedItems(parsedContent);
+  if (!normalized.length) {
+    throw new Error("NO_ITEMS_FOUND");
+  }
+
+  return normalized;
+}
+
+export default async function handler(req, res) {
+  if (req.method === "OPTIONS") {
+    res.setHeader("Allow", "POST, OPTIONS");
+    return res.status(204).end();
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST, OPTIONS");
+    return sendJson(res, 405, { error: "Method not allowed" });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return sendJson(res, 500, { error: "OPENAI_API_KEY is not configured" });
+  }
+
+  let body;
+  try {
+    body = await parseBody(req);
+  } catch (error) {
+    if (error instanceof Error && error.message === "EMPTY_BODY") {
+      return sendJson(res, 400, { error: "Request body is required" });
+    }
+    return sendJson(res, 400, { error: "Request body must be valid JSON" });
+  }
+
+  const imageUrl =
+    typeof body?.imageUrl === "string" ? body.imageUrl.trim() : "";
+  const imageBase64 =
+    typeof body?.imageBase64 === "string" ? body.imageBase64.trim() : "";
+  const model =
+    typeof body?.model === "string" && body.model.trim()
+      ? body.model.trim()
+      : DEFAULT_MODEL;
+
+  if (!imageUrl && !imageBase64) {
+    return sendJson(res, 400, {
+      error: "Provide either imageUrl or imageBase64",
+    });
+  }
+
+  let imageReference = imageUrl;
+  if (!imageReference && imageBase64) {
+    const encodedPart = imageBase64.includes(",")
+      ? imageBase64.split(",")[1]
+      : imageBase64;
+    const estimatedBytes = estimateBase64Bytes(encodedPart);
+    if (estimatedBytes > MAX_IMAGE_BYTES) {
+      return sendJson(res, 413, {
+        error: `Image too large. Max supported size is ${MAX_IMAGE_BYTES} bytes`,
+      });
+    }
+    imageReference = toImageDataUrl(imageBase64);
+  }
+
+  try {
+    const items = await extractItemsFromImage({
+      imageReference,
+      model,
+      apiKey,
+    });
+    return sendJson(res, 200, { items });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("OPENAI_ERROR:")) {
+      const [, statusCode] = error.message.split(":");
+      return sendJson(res, 502, {
+        error: "Failed to extract items from vision model",
+        upstreamStatus: Number(statusCode),
+      });
+    }
+
+    if (error instanceof Error && error.message === "NO_ITEMS_FOUND") {
+      return sendJson(res, 422, {
+        error: "No billable items could be extracted from the image",
+      });
+    }
+
+    return sendJson(res, 500, { error: "Failed to process receipt image" });
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,10 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/src/pages/UploadReceipt.css
+++ b/src/pages/UploadReceipt.css
@@ -1,7 +1,7 @@
 .upload-receipt-container {
-  max-width: 400px;
-  margin: 40px auto;
-  padding: 32px 24px;
+  max-width: 440px;
+  margin: 24px auto;
+  padding: 24px;
   background: #fff;
   border-radius: 16px;
   box-shadow: 0 2px 16px rgba(0, 0, 0, 0.07);
@@ -15,8 +15,9 @@
 }
 
 .upload-receipt-container p {
-  margin-bottom: 20px;
+  margin-bottom: 16px;
   color: #555;
+  text-align: center;
 }
 
 .upload-btn,
@@ -26,7 +27,7 @@
   border: none;
   border-radius: 8px;
   padding: 10px 24px;
-  margin: 8px 0;
+  margin: 0;
   font-size: 1rem;
   cursor: pointer;
   transition: background 0.2s;
@@ -42,9 +43,34 @@
   cursor: not-allowed;
 }
 
+.image-actions {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.image-input {
+  display: none;
+}
+
+.selected-image-name {
+  font-size: 0.92rem;
+  margin: 6px 0;
+  color: #6b7280;
+  word-break: break-all;
+}
+
+.input-divider {
+  margin: 10px 0 8px;
+  color: #6b7280;
+  font-size: 0.92rem;
+}
+
 .json-paste-section {
   width: 100%;
-  margin-top: 12px;
+  margin-top: 2px;
 }
 
 .json-paste-section label {
@@ -52,6 +78,7 @@
   font-weight: 600;
   margin-bottom: 8px;
   text-align: left;
+  color: #374151;
 }
 
 .json-paste-section textarea {
@@ -63,12 +90,24 @@
   font-family: monospace;
   font-size: 0.95rem;
   resize: vertical;
+  margin-bottom: 10px;
+}
+
+.receipt-preview {
+  width: 100%;
+  max-height: 260px;
+  object-fit: contain;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  margin: 8px 0 10px;
+  background: #f9fafb;
 }
 
 .json-error,
-.json-success {
+.json-success,
+.json-status {
   font-size: 0.95rem;
-  margin: 8px 0 0 0;
+  margin: 6px 0 0 0;
   text-align: center;
 }
 
@@ -78,4 +117,8 @@
 
 .json-success {
   color: #047857;
+}
+
+.json-status {
+  color: #4338ca;
 }

--- a/src/pages/UploadReceipt.jsx
+++ b/src/pages/UploadReceipt.jsx
@@ -1,15 +1,68 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import "./UploadReceipt.css";
 
+const MAX_IMAGE_BYTES = 7 * 1024 * 1024;
+
 const UploadReceipt = ({ onNext }) => {
+  const cameraInputRef = useRef(null);
+  const uploadInputRef = useRef(null);
   const [jsonInput, setJsonInput] = useState("");
+  const [imagePreview, setImagePreview] = useState("");
+  const [selectedImageName, setSelectedImageName] = useState("");
+  const [uploadError, setUploadError] = useState("");
   const [jsonError, setJsonError] = useState("");
+  const [isExtracting, setIsExtracting] = useState(false);
   const [extractedItems, setExtractedItems] = useState([]);
+
+  const parseErrorMessage = async (response) => {
+    try {
+      const errorPayload = await response.json();
+      if (typeof errorPayload?.error === "string" && errorPayload.error.trim()) {
+        return errorPayload.error.trim();
+      }
+    } catch {
+      return "Failed to extract receipt items.";
+    }
+    return "Failed to extract receipt items.";
+  };
+
+  const readFileAsDataUrl = (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result !== "string") {
+          reject(new Error("Failed to read image file."));
+          return;
+        }
+        resolve(reader.result);
+      };
+      reader.onerror = () => reject(new Error("Failed to read image file."));
+      reader.readAsDataURL(file);
+    });
+
+  const normalizeApiItems = (items) => {
+    if (!Array.isArray(items)) return [];
+
+    return items.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const name = typeof item.name === "string" ? item.name.trim() : "";
+      const quantity = Math.max(
+        1,
+        Number.parseInt(String(item.quantity ?? 1), 10) || 1
+      );
+      const unitPrice = Number.parseFloat(String(item.unitPrice));
+      if (!name || !Number.isFinite(unitPrice) || unitPrice < 0) return [];
+      return Array.from({ length: quantity }, () => ({
+        name,
+        price: unitPrice.toFixed(2),
+      }));
+    });
+  };
 
   const toNumber = (value) => {
     if (typeof value === "number" && Number.isFinite(value)) return value;
     if (typeof value === "string") {
-      const parsed = parseFloat(value.replace(/[^0-9.-]/g, ""));
+      const parsed = Number.parseFloat(value.replace(/[^0-9.-]/g, ""));
       return Number.isFinite(parsed) ? parsed : null;
     }
     return null;
@@ -20,16 +73,15 @@ const UploadReceipt = ({ onNext }) => {
 
     const quantity = Math.max(
       1,
-      parseInt(item.quantity ?? item.qty ?? item.count ?? 1, 10) || 1
+      Number.parseInt(String(item.quantity ?? item.qty ?? item.count ?? 1), 10) ||
+        1
     );
-
     const name =
       item.name ||
       item.item ||
       item.title ||
       item.description ||
       item.productName;
-
     const unitPrice = toNumber(
       item.unitPrice ??
         item.unit_price ??
@@ -42,8 +94,8 @@ const UploadReceipt = ({ onNext }) => {
       unitPrice !== null
         ? unitPrice
         : totalPrice !== null
-        ? totalPrice / quantity
-        : null;
+          ? totalPrice / quantity
+          : null;
 
     if (!name || resolvedPrice === null) return [];
     return Array.from({ length: quantity }, () => ({
@@ -80,7 +132,77 @@ const UploadReceipt = ({ onNext }) => {
     return [];
   };
 
+  const extractItemsFromImage = async (imageBase64) => {
+    const response = await fetch("/api/extract-items", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ imageBase64 }),
+    });
+
+    if (!response.ok) {
+      throw new Error(await parseErrorMessage(response));
+    }
+
+    const payload = await response.json();
+    const normalized = normalizeApiItems(payload?.items);
+    if (!normalized.length) {
+      throw new Error("No items were found in that image.");
+    }
+    return normalized;
+  };
+
+  const handleImageSelection = async (file) => {
+    if (!file) return;
+    setUploadError("");
+    setJsonError("");
+    setExtractedItems([]);
+
+    if (!file.type.startsWith("image/")) {
+      setUploadError("Please select an image file.");
+      return;
+    }
+
+    if (file.size > MAX_IMAGE_BYTES) {
+      setUploadError("Image is too large. Please use one smaller than 7MB.");
+      return;
+    }
+
+    setSelectedImageName(file.name);
+    setIsExtracting(true);
+
+    try {
+      const imageBase64 = await readFileAsDataUrl(file);
+      setImagePreview(imageBase64);
+      const normalizedItems = await extractItemsFromImage(imageBase64);
+      setExtractedItems(normalizedItems);
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "Failed to extract receipt items.";
+      setUploadError(message);
+      setExtractedItems([]);
+    } finally {
+      setIsExtracting(false);
+    }
+  };
+
+  const handleCameraChange = async (event) => {
+    const [file] = event.target.files || [];
+    await handleImageSelection(file);
+    event.target.value = "";
+  };
+
+  const handleUploadChange = async (event) => {
+    const [file] = event.target.files || [];
+    await handleImageSelection(file);
+    event.target.value = "";
+  };
+
   const handleExtractJson = () => {
+    setUploadError("");
     if (!jsonInput.trim()) {
       setJsonError("Paste JSON first.");
       setExtractedItems([]);
@@ -99,8 +221,8 @@ const UploadReceipt = ({ onNext }) => {
         return;
       }
 
-      setExtractedItems(normalized);
       setJsonError("");
+      setExtractedItems(normalized);
     } catch {
       setJsonError("Invalid JSON. Please check the format and try again.");
       setExtractedItems([]);
@@ -116,31 +238,84 @@ const UploadReceipt = ({ onNext }) => {
   return (
     <div className="upload-receipt-container">
       <h2>Upload Receipt</h2>
-      <p>Paste your receipt JSON to extract ordered items.</p>
+      <p>Take a receipt photo or upload one to extract ordered items.</p>
+
+      <div className="image-actions">
+        <button
+          className="upload-btn"
+          onClick={() => cameraInputRef.current?.click()}
+          disabled={isExtracting}
+        >
+          Use Camera
+        </button>
+        <button
+          className="upload-btn"
+          onClick={() => uploadInputRef.current?.click()}
+          disabled={isExtracting}
+        >
+          Upload Image
+        </button>
+      </div>
+
+      <input
+        ref={cameraInputRef}
+        className="image-input"
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={handleCameraChange}
+      />
+      <input
+        ref={uploadInputRef}
+        className="image-input"
+        type="file"
+        accept="image/*"
+        onChange={handleUploadChange}
+      />
+
+      {selectedImageName && (
+        <p className="selected-image-name">Selected image: {selectedImageName}</p>
+      )}
+      {imagePreview && (
+        <img
+          className="receipt-preview"
+          src={imagePreview}
+          alt="Receipt preview"
+        />
+      )}
+
+      {isExtracting && <p className="json-status">Extracting items...</p>}
+      {uploadError && <p className="json-error">{uploadError}</p>}
+
+      <p className="input-divider">or paste JSON</p>
       <div className="json-paste-section">
         <label htmlFor="receipt-json-input">Paste receipt JSON</label>
         <textarea
           id="receipt-json-input"
           value={jsonInput}
-          onChange={(e) => setJsonInput(e.target.value)}
+          onChange={(event) => setJsonInput(event.target.value)}
           placeholder='{"items":[{"name":"Pasta","price":14.99}]}'
-          rows={7}
+          rows={6}
+          disabled={isExtracting}
         />
-        <button className="upload-btn" onClick={handleExtractJson}>
-          Extract Ordered Items
+        <button
+          className="upload-btn"
+          onClick={handleExtractJson}
+          disabled={isExtracting}
+        >
+          Extract from JSON
         </button>
       </div>
       {jsonError && <p className="json-error">{jsonError}</p>}
       {extractedItems.length > 0 && (
         <p className="json-success">
-          Extracted {extractedItems.length} item
-          {extractedItems.length === 1 ? "" : "s"} from JSON.
+          Extracted {extractedItems.length} item{extractedItems.length === 1 ? "" : "s"}.
         </p>
       )}
       <button
         className="next-btn"
         onClick={handleNext}
-        disabled={extractedItems.length === 0}
+        disabled={extractedItems.length === 0 || isExtracting}
       >
         Next
       </button>


### PR DESCRIPTION
## Summary
- add a new serverless endpoint at /api/extract-items that accepts imageBase64 or imageUrl and extracts billable receipt items as structured JSON
- update Upload Receipt UI to support camera capture, image upload, and manual JSON paste as parallel input options
- add loading/error states, image preview, and normalization into the existing item format used by the app
- document backend setup (OPENAI_API_KEY) and allow Node globals in ESLint config for api files

## Notes
- this keeps OpenAI usage limits as the primary safeguard and does not include Upstash-based rate limiting
