### PR TITLE
Fix receipt image extraction parsing for vision responses

### DIFF
--- a/api/extract-items.js
+++ b/api/extract-items.js
@@ -44,6 +44,44 @@ function normalizeExtractedItems(payload) {
     .filter(Boolean);
 }
 
+function extractRawContent(completionPayload) {
+  const content = completionPayload?.choices?.[0]?.message?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    const joinedText = content
+      .map((part) => {
+        if (!part || typeof part !== "object") return "";
+        if (typeof part.text === "string") return part.text;
+        return "";
+      })
+      .join("")
+      .trim();
+    if (joinedText) return joinedText;
+  }
+
+  return "";
+}
+
+function parseJsonContent(rawContent) {
+  const trimmed = rawContent.trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const fenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+    if (!fenceMatch?.[1]) return null;
+    try {
+      return JSON.parse(fenceMatch[1]);
+    } catch {
+      return null;
+    }
+  }
+}
+
 function parseBody(req) {
   if (req.body && typeof req.body === "object") {
     return Promise.resolve(req.body);
@@ -150,15 +188,13 @@ async function extractItemsFromImage({ imageReference, model, apiKey }) {
   }
 
   const completion = await response.json();
-  const rawContent = completion?.choices?.[0]?.message?.content;
-  if (typeof rawContent !== "string" || !rawContent.trim()) {
+  const rawContent = extractRawContent(completion);
+  if (!rawContent) {
     throw new Error("EMPTY_MODEL_RESPONSE");
   }
 
-  let parsedContent;
-  try {
-    parsedContent = JSON.parse(rawContent);
-  } catch {
+  const parsedContent = parseJsonContent(rawContent);
+  if (!parsedContent) {
     throw new Error("INVALID_MODEL_JSON");
   }
 


### PR DESCRIPTION
Receipt image extraction was failing because the API handler expected a single response shape from the vision model. In practice, model output can come back as either plain text or structured content blocks, and sometimes JSON is wrapped in markdown fences.

## What changed
- Added resilient content extraction for `choices[0].message.content` when returned as either a string or an array of text parts.
- Added JSON parsing fallback for fenced ```json blocks in addition to direct JSON strings.
- Kept existing item normalization and validation behavior unchanged after parsing succeeds.

## Impact
This prevents false extraction failures caused by response-shape variance and restores successful item extraction from uploaded receipt images.