### PR TITLE
Fix receipt extraction for unsupported image formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ export OPENAI_API_KEY="your_api_key_here"
 ```
 
 You can also send `"imageUrl"` instead of `"imageBase64"`.  
+Supported image formats: JPG, PNG, WEBP, and GIF.
 Response format:
 
 ```json

--- a/api/extract-items.js
+++ b/api/extract-items.js
@@ -1,6 +1,13 @@
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
 const DEFAULT_MODEL = "gpt-4.1-mini";
 const MAX_IMAGE_BYTES = 7 * 1024 * 1024;
+const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
 
 function sendJson(res, status, payload) {
   return res.status(status).json(payload);
@@ -15,6 +22,12 @@ function estimateBase64Bytes(base64Value) {
 function toImageDataUrl(imageBase64) {
   if (imageBase64.startsWith("data:image/")) return imageBase64;
   return `data:image/jpeg;base64,${imageBase64}`;
+}
+
+function extractDataUrlMimeType(dataUrl) {
+  const match = /^data:([^;,]+)[;,]/i.exec(dataUrl);
+  if (!match?.[1]) return "";
+  return String(match[1]).toLowerCase();
 }
 
 function safePrice(value) {
@@ -259,6 +272,13 @@ export default async function handler(req, res) {
       });
     }
     imageReference = toImageDataUrl(imageBase64);
+    const mimeType = extractDataUrlMimeType(imageReference);
+    if (mimeType && !SUPPORTED_IMAGE_TYPES.has(mimeType)) {
+      return sendJson(res, 415, {
+        error:
+          "Unsupported image format. Please upload JPG, PNG, WEBP, or GIF.",
+      });
+    }
   }
 
   try {

--- a/src/pages/AddItems.jsx
+++ b/src/pages/AddItems.jsx
@@ -9,6 +9,13 @@ import DeleteIcon from "../assets/icons/DeleteIcon";
 import EditIcon from "../assets/icons/EditIcon";
 
 const MAX_IMAGE_BYTES = 7 * 1024 * 1024;
+const SUPPORTED_UPLOAD_TYPES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
 
 function AddItems({ items, setItems, setActiveTab }) {
   // Active add mode: null | 'scan' | 'upload' | 'manual'
@@ -58,6 +65,45 @@ function AddItems({ items, setItems, setActiveTab }) {
       reader.onerror = () => reject(new Error("Failed to read image file."));
       reader.readAsDataURL(file);
     });
+
+  const convertImageToJpegDataUrl = (file) =>
+    new Promise((resolve, reject) => {
+      const objectUrl = URL.createObjectURL(file);
+      const image = new Image();
+
+      image.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = image.naturalWidth || image.width;
+        canvas.height = image.naturalHeight || image.height;
+        const context = canvas.getContext("2d");
+        if (!context) {
+          URL.revokeObjectURL(objectUrl);
+          reject(new Error("Failed to process image file."));
+          return;
+        }
+        context.fillStyle = "#ffffff";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+        context.drawImage(image, 0, 0);
+        const jpegDataUrl = canvas.toDataURL("image/jpeg", 0.92);
+        URL.revokeObjectURL(objectUrl);
+        resolve(jpegDataUrl);
+      };
+
+      image.onerror = () => {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error("Failed to process image file."));
+      };
+
+      image.src = objectUrl;
+    });
+
+  const toUploadDataUrl = async (file) => {
+    const fileType = String(file.type || "").toLowerCase();
+    if (SUPPORTED_UPLOAD_TYPES.has(fileType)) {
+      return readFileAsDataUrl(file);
+    }
+    return convertImageToJpegDataUrl(file);
+  };
 
   const normalizeApiItems = (apiItems) => {
     if (!Array.isArray(apiItems)) return [];
@@ -110,7 +156,7 @@ function AddItems({ items, setItems, setActiveTab }) {
     setSelectedImageName(file.name);
     setIsExtracting(true);
     try {
-      const imageBase64 = await readFileAsDataUrl(file);
+      const imageBase64 = await toUploadDataUrl(file);
       setImagePreview(imageBase64);
       const extracted = await extractItemsFromImage(imageBase64);
       setItems((prev) => [...prev, ...extracted]);


### PR DESCRIPTION
Receipt item extraction was failing for some phone-captured images because unsupported formats could be sent directly to the extraction API. This change makes uploads more resilient and returns clearer API feedback when a format is not supported.

## What changed
- Convert unsupported uploaded image types to JPEG in the client before calling `/api/extract-items`.
- Keep direct pass-through for already supported types (JPG, PNG, WEBP, GIF).
- Validate data URL MIME type in the API and return `415` with a clear unsupported-format message.
- Document supported formats in the README.

## Notes for reviewers
Client-side conversion uses a canvas export to JPEG with a white background so extraction can proceed consistently even when source files are not directly accepted by the vision pipeline.