### PR TITLE
Improve receipt extraction endpoint errors and backend URL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ Open http://localhost:5173 in your browser.
 
 ### Configure receipt extraction API
 
-Set this environment variable before running serverless APIs locally/deployed:
+Set these environment variables before running receipt extraction:
 
 ```sh
 export OPENAI_API_KEY="your_api_key_here"
+export VITE_RECEIPT_EXTRACT_API_URL="https://your-backend.example.com/api/extract-items"
 ```
+
+`VITE_RECEIPT_EXTRACT_API_URL` is optional in environments that already serve `/api/extract-items` on the same host (for example Vercel serverless).  
+For static hosting (like GitHub Pages), you must point this to a separately deployed backend endpoint.
 
 `POST /api/extract-items` accepts JSON:
 

--- a/src/pages/UploadReceipt.jsx
+++ b/src/pages/UploadReceipt.jsx
@@ -2,6 +2,8 @@ import React, { useRef, useState } from "react";
 import "./UploadReceipt.css";
 
 const MAX_IMAGE_BYTES = 7 * 1024 * 1024;
+const RECEIPT_EXTRACT_ENDPOINT =
+  import.meta.env.VITE_RECEIPT_EXTRACT_API_URL?.trim() || "/api/extract-items";
 
 const UploadReceipt = ({ onNext }) => {
   const cameraInputRef = useRef(null);
@@ -15,18 +17,46 @@ const UploadReceipt = ({ onNext }) => {
   const [extractedItems, setExtractedItems] = useState([]);
 
   const parseErrorMessage = async (response) => {
+    const statusSuffix = ` (HTTP ${response.status})`;
+
     try {
-      const errorPayload = await response.json();
-      if (
-        typeof errorPayload?.error === "string" &&
-        errorPayload.error.trim()
-      ) {
-        return errorPayload.error.trim();
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        const errorPayload = await response.json();
+        if (
+          typeof errorPayload?.error === "string" &&
+          errorPayload.error.trim()
+        ) {
+          return `${errorPayload.error.trim()}${statusSuffix}`;
+        }
       }
-    } catch {
-      return "Failed to extract receipt items.";
+    } catch (error) {
+      void error;
     }
-    return "Failed to extract receipt items.";
+
+    try {
+      const errorText = (await response.text()).trim();
+      if (errorText) {
+        if (
+          errorText.toLowerCase().includes("<!doctype html") ||
+          errorText.toLowerCase().includes("<html")
+        ) {
+          return (
+            `Receipt extraction endpoint is unavailable${statusSuffix}. ` +
+            "Set VITE_RECEIPT_EXTRACT_API_URL to your backend /api/extract-items URL."
+          );
+        }
+        return `${errorText}${statusSuffix}`;
+      }
+    } catch (error) {
+      void error;
+    }
+
+    if (response.status === 404) {
+      return "Receipt extraction endpoint was not found (HTTP 404).";
+    }
+
+    return `Failed to extract receipt items${statusSuffix}.`;
   };
 
   const readFileAsDataUrl = (file) =>
@@ -140,7 +170,7 @@ const UploadReceipt = ({ onNext }) => {
   };
 
   const extractItemsFromImage = async (imageBase64) => {
-    const response = await fetch("/api/extract-items", {
+    const response = await fetch(RECEIPT_EXTRACT_ENDPOINT, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
Receipt item extraction was failing with a generic message, which made recent backend/environment mismatches hard to diagnose. This updates the upload flow to surface actionable API failures and makes the extraction endpoint configurable so static-hosted frontends can point to a deployed backend.

## What changed
- Added `RECEIPT_EXTRACT_ENDPOINT` in `UploadReceipt` using `VITE_RECEIPT_EXTRACT_API_URL` with `/api/extract-items` as fallback.
- Improved non-OK response parsing to include HTTP status and return clearer messages for JSON errors, HTML/not-served responses, and 404s.
- Updated README configuration docs to include `VITE_RECEIPT_EXTRACT_API_URL` and explain when it is required (for example GitHub Pages/static hosting).

## Notes for reviewers
- Behavior is unchanged when `/api/extract-items` is available on the same origin.
- Main UX change is better user-facing error details when the backend route is missing or misconfigured.