### PR TITLE
Fix 413 errors when uploading receipt images

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ export OPENAI_API_KEY="your_api_key_here"
 }
 ```
 
+Images are automatically compressed client-side before upload to stay within serverless payload limits (about 4MB request body, ~3MB decoded image).
+
 You can also send `"imageUrl"` instead of `"imageBase64"`.  
 Response format:
 

--- a/api/extract-items.js
+++ b/api/extract-items.js
@@ -1,6 +1,7 @@
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
 const DEFAULT_MODEL = "gpt-4.1-mini";
-const MAX_IMAGE_BYTES = 7 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 3 * 1024 * 1024;
+const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
 
 function sendJson(res, status, payload) {
   return res.status(status).json(payload);
@@ -46,10 +47,20 @@ function normalizeExtractedItems(payload) {
 
 function parseBody(req) {
   if (req.body && typeof req.body === "object") {
+    try {
+      if (Buffer.byteLength(JSON.stringify(req.body), "utf8") > MAX_REQUEST_BODY_BYTES) {
+        return Promise.reject(new Error("BODY_TOO_LARGE"));
+      }
+    } catch {
+      return Promise.reject(new Error("INVALID_JSON_BODY"));
+    }
     return Promise.resolve(req.body);
   }
 
   if (typeof req.body === "string" && req.body.trim()) {
+    if (Buffer.byteLength(req.body, "utf8") > MAX_REQUEST_BODY_BYTES) {
+      return Promise.reject(new Error("BODY_TOO_LARGE"));
+    }
     try {
       return Promise.resolve(JSON.parse(req.body));
     } catch {
@@ -59,7 +70,15 @@ function parseBody(req) {
 
   return new Promise((resolve, reject) => {
     const chunks = [];
-    req.on("data", (chunk) => chunks.push(chunk));
+    let totalSize = 0;
+    req.on("data", (chunk) => {
+      chunks.push(chunk);
+      totalSize += chunk.length;
+      if (totalSize > MAX_REQUEST_BODY_BYTES) {
+        reject(new Error("BODY_TOO_LARGE"));
+        req.destroy();
+      }
+    });
     req.on("end", () => {
       const raw = Buffer.concat(chunks).toString("utf8").trim();
       if (!raw) {
@@ -190,6 +209,11 @@ export default async function handler(req, res) {
   try {
     body = await parseBody(req);
   } catch (error) {
+    if (error instanceof Error && error.message === "BODY_TOO_LARGE") {
+      return sendJson(res, 413, {
+        error: "Request body is too large. Upload a smaller image.",
+      });
+    }
     if (error instanceof Error && error.message === "EMPTY_BODY") {
       return sendJson(res, 400, { error: "Request body is required" });
     }

--- a/src/pages/UploadReceipt.jsx
+++ b/src/pages/UploadReceipt.jsx
@@ -1,7 +1,12 @@
 import React, { useRef, useState } from "react";
 import "./UploadReceipt.css";
 
-const MAX_IMAGE_BYTES = 7 * 1024 * 1024;
+const MAX_SOURCE_IMAGE_BYTES = 20 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 3 * 1024 * 1024;
+const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024;
+const MAX_IMAGE_DIMENSION = 2200;
+const SCALE_RETRY_MULTIPLIER = 0.85;
+const QUALITY_STEPS = [0.9, 0.82, 0.74, 0.66, 0.58, 0.5, 0.42];
 
 const UploadReceipt = ({ onNext }) => {
   const cameraInputRef = useRef(null);
@@ -15,6 +20,10 @@ const UploadReceipt = ({ onNext }) => {
   const [extractedItems, setExtractedItems] = useState([]);
 
   const parseErrorMessage = async (response) => {
+    if (response.status === 413) {
+      return "Image is too large to process. Try cropping the receipt photo and re-uploading.";
+    }
+
     try {
       const errorPayload = await response.json();
       if (typeof errorPayload?.error === "string" && errorPayload.error.trim()) {
@@ -26,19 +35,73 @@ const UploadReceipt = ({ onNext }) => {
     return "Failed to extract receipt items.";
   };
 
-  const readFileAsDataUrl = (file) =>
+  const estimateBase64Bytes = (base64Value) => {
+    const clean = base64Value.replace(/\s/g, "");
+    const padding = clean.endsWith("==") ? 2 : clean.endsWith("=") ? 1 : 0;
+    return Math.floor((clean.length * 3) / 4) - padding;
+  };
+
+  const estimateRequestPayloadBytes = (imageDataUrl) =>
+    new TextEncoder().encode(JSON.stringify({ imageBase64: imageDataUrl })).length;
+
+  const loadImageFromObjectUrl = (file) =>
     new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        if (typeof reader.result !== "string") {
-          reject(new Error("Failed to read image file."));
-          return;
-        }
-        resolve(reader.result);
+      const objectUrl = URL.createObjectURL(file);
+      const image = new Image();
+      image.onload = () => {
+        URL.revokeObjectURL(objectUrl);
+        resolve(image);
       };
-      reader.onerror = () => reject(new Error("Failed to read image file."));
-      reader.readAsDataURL(file);
+      image.onerror = () => {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error("Failed to read image file."));
+      };
+      image.src = objectUrl;
     });
+
+  const drawToCanvas = (image, width, height) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Failed to process image.");
+    }
+    context.drawImage(image, 0, 0, width, height);
+    return canvas;
+  };
+
+  const prepareImageForUpload = async (file) => {
+    const image = await loadImageFromObjectUrl(file);
+    let width = image.naturalWidth || image.width;
+    let height = image.naturalHeight || image.height;
+    const largestDimension = Math.max(width, height);
+    if (largestDimension > MAX_IMAGE_DIMENSION) {
+      const scale = MAX_IMAGE_DIMENSION / largestDimension;
+      width = Math.max(1, Math.round(width * scale));
+      height = Math.max(1, Math.round(height * scale));
+    }
+
+    for (let pass = 0; pass < 4; pass += 1) {
+      const canvas = drawToCanvas(image, width, height);
+      for (const quality of QUALITY_STEPS) {
+        const dataUrl = canvas.toDataURL("image/jpeg", quality);
+        const encodedPart = dataUrl.split(",")[1] || "";
+        const imageBytes = estimateBase64Bytes(encodedPart);
+        const payloadBytes = estimateRequestPayloadBytes(dataUrl);
+        if (imageBytes <= MAX_IMAGE_BYTES && payloadBytes <= MAX_REQUEST_BODY_BYTES) {
+          return dataUrl;
+        }
+      }
+
+      width = Math.max(1, Math.round(width * SCALE_RETRY_MULTIPLIER));
+      height = Math.max(1, Math.round(height * SCALE_RETRY_MULTIPLIER));
+    }
+
+    throw new Error(
+      "Image is too large to process. Crop the receipt and try again."
+    );
+  };
 
   const normalizeApiItems = (items) => {
     if (!Array.isArray(items)) return [];
@@ -164,8 +227,8 @@ const UploadReceipt = ({ onNext }) => {
       return;
     }
 
-    if (file.size > MAX_IMAGE_BYTES) {
-      setUploadError("Image is too large. Please use one smaller than 7MB.");
+    if (file.size > MAX_SOURCE_IMAGE_BYTES) {
+      setUploadError("Image is too large. Please use one smaller than 20MB.");
       return;
     }
 
@@ -173,7 +236,7 @@ const UploadReceipt = ({ onNext }) => {
     setIsExtracting(true);
 
     try {
-      const imageBase64 = await readFileAsDataUrl(file);
+      const imageBase64 = await prepareImageForUpload(file);
       setImagePreview(imageBase64);
       const normalizedItems = await extractItemsFromImage(imageBase64);
       setExtractedItems(normalizedItems);


### PR DESCRIPTION
Large receipt photos were being sent as full base64 payloads, which can exceed the serverless function request limit and fail with HTTP 413. This change makes uploads reliably fit payload constraints before calling the extraction API.

## What changed
1. Added client-side image preparation in `UploadReceipt` to resize and JPEG-compress selected images before upload.
2. Added payload-size estimation on the client so requests are only sent when they fit expected serverless limits.
3. Added matching server-side request-body guards in `/api/extract-items` and return a clear 413 error when exceeded.
4. Updated user-facing error messaging and README docs to reflect the new upload limits.

## Notes for reviewers
This keeps the existing `/api/extract-items` contract and only changes how large images are prepared and validated to avoid upstream request rejection.